### PR TITLE
shallow clone the llvm submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,6 +6,7 @@
 	path = src/llvm
 	url = https://praios.lf-net.org/littlefox/llvm-project.git
 	branch = lf-os
+	shallow = true
 [submodule "src/loader/efi"]
 	path = src/include/efi
 	branch = master


### PR DESCRIPTION
[llvm](https://praios.lf-net.org/littlefox/llvm-project) is fairly large — use a shallow clone to speed up pulling the submodule.